### PR TITLE
Support LBT in kernel

### DIFF
--- a/arch/loongarch/Kconfig
+++ b/arch/loongarch/Kconfig
@@ -131,6 +131,12 @@ config CPU_HAS_FPU
 	bool
 	default y
 
+config CPU_HAS_LBT
+	bool "Support for Loongson Binary Translation"
+	default y
+	help
+	  This option is used to enable LBT(Loongson Binary Translation)
+
 config CPU_HAS_PREFETCH
 	bool
 	default y

--- a/arch/loongarch/include/asm/asm-prototypes.h
+++ b/arch/loongarch/include/asm/asm-prototypes.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <linux/uaccess.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/mmu_context.h>
 #include <asm/page.h>
 #include <asm/ftrace.h>

--- a/arch/loongarch/include/asm/fpregdef.h
+++ b/arch/loongarch/include/asm/fpregdef.h
@@ -48,6 +48,5 @@
 #define fcsr1	$r1
 #define fcsr2	$r2
 #define fcsr3	$r3
-#define vcsr16	$r16
 
 #endif /* _ASM_FPREGDEF_H */

--- a/arch/loongarch/include/asm/lbt.h
+++ b/arch/loongarch/include/asm/lbt.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Author: Qi Hu <huqi@loongson.cn>
+ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
+ */
+#ifndef _ASM_LBT_H
+#define _ASM_LBT_H
+
+#include <linux/sched.h>
+#include <linux/sched/task_stack.h>
+#include <linux/ptrace.h>
+#include <linux/thread_info.h>
+#include <linux/bitops.h>
+
+#include <asm/cpu.h>
+#include <asm/cpu-features.h>
+#include <asm/current.h>
+#include <asm/loongarch.h>
+#include <asm/processor.h>
+#include <asm/ptrace.h>
+
+#ifdef CONFIG_CPU_HAS_LBT
+
+extern void _save_lbt(struct thread_struct *);
+extern void _restore_lbt(struct thread_struct *);
+
+static inline int is_lbt_enabled(void)
+{
+	if (!cpu_has_lbt)
+		return 0;
+	return (csr_read32(LOONGARCH_CSR_EUEN) & CSR_EUEN_LBTEN) ?
+		1 : 0;
+}
+
+static inline int thread_lbt_context_live(void)
+{
+	if (!cpu_has_lbt)
+		return 0;
+	return test_thread_flag(TIF_LBT_CTX_LIVE);
+}
+
+#define enable_lbt()		set_csr_euen(CSR_EUEN_LBTEN)
+#define disable_lbt()		clear_csr_euen(CSR_EUEN_LBTEN)
+
+static inline int is_lbt_owner(void)
+{
+	return test_thread_flag(TIF_USEDLBT);
+}
+
+static inline void __own_lbt(void)
+{
+	enable_lbt();
+	set_thread_flag(TIF_USEDLBT);
+	KSTK_EUEN(current) |= CSR_EUEN_LBTEN;
+}
+
+static inline void own_lbt_inatomic(int restore)
+{
+	if (cpu_has_lbt && !is_lbt_owner()) {
+		__own_lbt();
+		if (restore)
+			_restore_lbt(&current->thread);
+	}
+}
+
+static inline void own_lbt(int restore)
+{
+	preempt_disable();
+	own_lbt_inatomic(restore);
+	preempt_enable();
+}
+
+static inline void __lose_lbt(struct task_struct *tsk)
+{
+	disable_lbt();
+	clear_tsk_thread_flag(tsk, TIF_USEDLBT);
+	KSTK_EUEN(tsk) &= ~(CSR_EUEN_LBTEN);
+}
+
+static inline void lose_lbt_inatomic(int save, struct task_struct *tsk)
+{
+	if (cpu_has_lbt && is_lbt_owner()) {
+		if (save)
+			_save_lbt(&tsk->thread);
+		__lose_lbt(tsk);
+	}
+}
+
+static inline void lose_lbt(int save)
+{
+	preempt_disable();
+	lose_lbt_inatomic(save, current);
+	preempt_enable();
+}
+
+static inline void init_lbt(void)
+{
+	set_thread_flag(TIF_LBT_CTX_LIVE);
+	__own_lbt();
+}
+
+/* these functions are not used yet */
+static inline void save_lbt(struct task_struct *tsk)
+{
+	if (cpu_has_lbt)
+		_save_lbt(&tsk->thread);
+}
+
+static inline void restore_lbt(struct task_struct *tsk)
+{
+	if (cpu_has_lbt)
+		_restore_lbt(&tsk->thread);
+}
+#else
+static inline void own_lbt_inatomic(int restore)
+{}
+static inline void lose_lbt_inatomic(int save, struct task_struct *tsk)
+{}
+static inline void own_lbt(int restore)
+{}
+static inline void lose_lbt(int save)
+{}
+#endif
+
+#endif /* _ASM_LBT_H */

--- a/arch/loongarch/include/asm/loongarch.h
+++ b/arch/loongarch/include/asm/loongarch.h
@@ -1496,6 +1496,10 @@ __BUILD_CSR_OP(tlbidx)
 #define FPU_CSR_RU	0x200	/* towards +Infinity */
 #define FPU_CSR_RD	0x300	/* towards -Infinity */
 
+/* Bit 6 of FPU Status Register specify the LBT TOP simulation mode */
+#define FPU_CSR_TM_SHIFT	0x6
+#define FPU_CSR_TM			(_ULCAST_(1) << FPU_CSR_TM_SHIFT)
+
 #define read_fcsr(source)	\
 ({	\
 	unsigned int __res;	\

--- a/arch/loongarch/include/asm/processor.h
+++ b/arch/loongarch/include/asm/processor.h
@@ -80,7 +80,6 @@ BUILD_FPR_ACCESS(64)
 
 struct loongarch_fpu {
 	unsigned int	fcsr;
-	unsigned int	vcsr;
 	uint64_t	fcc;	/* 8x8 */
 	union fpureg	fpr[NUM_FPU_REGS];
 };
@@ -161,7 +160,6 @@ struct thread_struct {
 	 */							\
 	.fpu			= {				\
 		.fcsr		= 0,				\
-		.vcsr		= 0,				\
 		.fcc		= 0,				\
 		.fpr		= {{{0,},},},			\
 	},							\

--- a/arch/loongarch/include/asm/processor.h
+++ b/arch/loongarch/include/asm/processor.h
@@ -81,6 +81,7 @@ BUILD_FPR_ACCESS(64)
 struct loongarch_fpu {
 	unsigned int	fcsr;
 	uint64_t	fcc;	/* 8x8 */
+	uint64_t	ftop;
 	union fpureg	fpr[NUM_FPU_REGS];
 };
 

--- a/arch/loongarch/include/asm/switch_to.h
+++ b/arch/loongarch/include/asm/switch_to.h
@@ -7,6 +7,7 @@
 
 #include <asm/cpu-features.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 
 struct task_struct;
 
@@ -31,6 +32,7 @@ extern asmlinkage struct task_struct *__switch_to(struct task_struct *prev,
 #define switch_to(prev, next, last)					\
 do {									\
 	lose_fpu_inatomic(1, prev);					\
+	lose_lbt_inatomic(1, prev);					\
 	(last) = __switch_to(prev, next, task_thread_info(next));	\
 } while (0)
 

--- a/arch/loongarch/include/asm/thread_info.h
+++ b/arch/loongarch/include/asm/thread_info.h
@@ -84,6 +84,8 @@ register unsigned long current_stack_pointer __asm__("$r3");
 #define TIF_SINGLESTEP		16	/* Single Step */
 #define TIF_LSX_CTX_LIVE	17	/* LSX context must be preserved */
 #define TIF_LASX_CTX_LIVE	18	/* LASX context must be preserved */
+#define TIF_USEDLBT			19	/* LBT was used by this task this quantum (SMP) */
+#define TIF_LBT_CTX_LIVE	20	/* LBT context must be preserved */
 
 #define _TIF_SIGPENDING		(1<<TIF_SIGPENDING)
 #define _TIF_NEED_RESCHED	(1<<TIF_NEED_RESCHED)
@@ -101,6 +103,8 @@ register unsigned long current_stack_pointer __asm__("$r3");
 #define _TIF_SINGLESTEP		(1<<TIF_SINGLESTEP)
 #define _TIF_LSX_CTX_LIVE	(1<<TIF_LSX_CTX_LIVE)
 #define _TIF_LASX_CTX_LIVE	(1<<TIF_LASX_CTX_LIVE)
+#define _TIF_USEDLBT		(1<<TIF_USEDLBT)
+#define _TIF_LBT_CTX_LIVE	(1<<TIF_LBT_CTX_LIVE)
 
 #endif /* __KERNEL__ */
 #endif /* _ASM_THREAD_INFO_H */

--- a/arch/loongarch/include/uapi/asm/ptrace.h
+++ b/arch/loongarch/include/uapi/asm/ptrace.h
@@ -44,6 +44,12 @@ struct user_fp_state {
 	uint64_t    fpr[32];
 	uint64_t    fcc;
 	uint32_t    fcsr;
+	uint8_t     ftop;
+};
+
+struct user_lbt_state {
+	uint64_t	scr[4];
+	uint32_t	eflags;
 };
 
 #define PTRACE_SYSEMU			0x1f

--- a/arch/loongarch/include/uapi/asm/sigcontext.h
+++ b/arch/loongarch/include/uapi/asm/sigcontext.h
@@ -39,6 +39,16 @@ struct fpu_context {
 	__u64	regs[32];
 	__u64	fcc;
 	__u32	fcsr;
+	__u8	ftop;
 };
+
+/* LBT context */
+#define LBT_CTX_MAGIC		0x4c425401
+#define LBT_CTX_ALIGN		8
+struct lbt_context {
+	__u64	scrs[4];
+	__u32	eflags;
+};
+
 
 #endif /* _UAPI_ASM_SIGCONTEXT_H */

--- a/arch/loongarch/kernel/Makefile
+++ b/arch/loongarch/kernel/Makefile
@@ -14,6 +14,8 @@ obj-$(CONFIG_EFI) 		+= efi.o
 
 obj-$(CONFIG_CPU_HAS_FPU)	+= fpu.o
 
+obj-$(CONFIG_CPU_HAS_LBT)	+= lbt.o
+
 obj-$(CONFIG_MODULES)		+= module.o module-sections.o
 
 obj-$(CONFIG_PROC_FS)		+= proc.o

--- a/arch/loongarch/kernel/asm-offsets.c
+++ b/arch/loongarch/kernel/asm-offsets.c
@@ -166,7 +166,6 @@ void output_thread_fpu_defines(void)
 
 	OFFSET(THREAD_FCSR, loongarch_fpu, fcsr);
 	OFFSET(THREAD_FCC,  loongarch_fpu, fcc);
-	OFFSET(THREAD_VCSR, loongarch_fpu, vcsr);
 	BLANK();
 }
 

--- a/arch/loongarch/kernel/asm-offsets.c
+++ b/arch/loongarch/kernel/asm-offsets.c
@@ -166,6 +166,7 @@ void output_thread_fpu_defines(void)
 
 	OFFSET(THREAD_FCSR, loongarch_fpu, fcsr);
 	OFFSET(THREAD_FCC,  loongarch_fpu, fcc);
+	OFFSET(THREAD_FTOP, loongarch_fpu, ftop);
 	BLANK();
 }
 

--- a/arch/loongarch/kernel/cpu-probe.c
+++ b/arch/loongarch/kernel/cpu-probe.c
@@ -123,6 +123,20 @@ static void cpu_probe_common(struct cpuinfo_loongarch *c)
 		c->options |= LOONGARCH_CPU_LVZ;
 		elf_hwcap |= HWCAP_LOONGARCH_LVZ;
 	}
+#ifdef CONFIG_CPU_HAS_LBT
+	if (config & CPUCFG2_X86BT) {
+		c->options |= LOONGARCH_CPU_LBT_X86;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_X86;
+	}
+	if (config & CPUCFG2_ARMBT) {
+		c->options |= LOONGARCH_CPU_LBT_ARM;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_ARM;
+	}
+	if (config & CPUCFG2_MIPSBT) {
+		c->options |= LOONGARCH_CPU_LBT_MIPS;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_MIPS;
+	}
+#endif
 
 	config = read_cpucfg(LOONGARCH_CPUCFG6);
 	if (config & CPUCFG6_PMP)

--- a/arch/loongarch/kernel/fpu.S
+++ b/arch/loongarch/kernel/fpu.S
@@ -146,16 +146,6 @@
 	movgr2fcsr	fcsr0, \tmp0
 	.endm
 
-	.macro sc_save_vcsr base, tmp0
-	movfcsr2gr	\tmp0, vcsr16
-	EX	st.w \tmp0, \base, 0
-	.endm
-
-	.macro sc_restore_vcsr base, tmp0
-	EX	ld.w \tmp0, \base, 0
-	movgr2fcsr	vcsr16, \tmp0
-	.endm
-
 /*
  * Save a thread's fp context.
  */

--- a/arch/loongarch/kernel/fpu.S
+++ b/arch/loongarch/kernel/fpu.S
@@ -139,12 +139,57 @@
 	.macro sc_save_fcsr base, tmp0
 	movfcsr2gr	\tmp0, fcsr0
 	EX	st.w \tmp0, \base, 0
+#if defined(CONFIG_CPU_HAS_LBT)
+	/* TM bit is always 0 if LBT not supported */
+	andi	\tmp0, \tmp0, FPU_CSR_TM
+	beqz	\tmp0, 1f
+	bstrins.d \tmp0, $r0, FPU_CSR_TM_SHIFT, FPU_CSR_TM_SHIFT
+	movgr2fcsr      fcsr0, \tmp0
+	1:
+#endif
 	.endm
 
 	.macro sc_restore_fcsr base, tmp0
 	EX	ld.w \tmp0, \base, 0
 	movgr2fcsr	fcsr0, \tmp0
 	.endm
+
+#if defined(CONFIG_CPU_HAS_LBT)
+	.macro sc_save_ftop base, tmp0
+	x86mftop \tmp0
+	EX	st.b \tmp0, \base, 0
+	.endm
+
+	.macro sc_restore_ftop base, tmp0, tmp1
+	EX	ld.b \tmp0, \base, 0
+	la.pcrel \tmp1, 1f
+	alsl.d \tmp1, \tmp0, \tmp1, 1
+	jirl $r0, \tmp1, 0
+	1:
+	x86mttop 0
+	b 1f
+	x86mttop 1
+	b 1f
+	x86mttop 2
+	b 1f
+	x86mttop 3
+	b 1f
+	x86mttop 4
+	b 1f
+	x86mttop 5
+	b 1f
+	x86mttop 6
+	b 1f
+	x86mttop 7
+	1:
+	.endm
+#else
+	.macro sc_save_ftop base, tmp0
+	.endm
+
+	.macro sc_restore_ftop base, tmp0, tmp1
+	.endm
+#endif
 
 /*
  * Save a thread's fp context.
@@ -162,7 +207,7 @@ EXPORT_SYMBOL(_save_fp)
  */
 SYM_FUNC_START(_restore_fp)
 	fpu_restore_double a0 t1		# clobbers t1
-	fpu_restore_csr	a0 t1
+	fpu_restore_csr	a0 t1 t2
 	fpu_restore_cc	a0 t1 t2		# clobbers t1, t2
 	jirl zero, ra, 0
 SYM_FUNC_END(_restore_fp)
@@ -223,9 +268,11 @@ SYM_FUNC_END(_init_fpu)
  * a0: fpregs
  * a1: fcc
  * a2: fcsr
+ * a3: ftop
  */
 SYM_FUNC_START(_save_fp_context)
 	sc_save_fcc a1 t1 t2
+	sc_save_ftop a3 t1
 	sc_save_fcsr a2 t1
 	sc_save_fp a0
 	li.w	a0, 0					# success
@@ -236,10 +283,12 @@ SYM_FUNC_END(_save_fp_context)
  * a0: fpregs
  * a1: fcc
  * a2: fcsr
+ * a3: ftop
  */
 SYM_FUNC_START(_restore_fp_context)
 	sc_restore_fp a0
 	sc_restore_fcc a1 t1 t2
+	sc_restore_ftop a3 t1 t2
 	sc_restore_fcsr a2 t1
 	li.w	a0, 0					# success
 	jirl zero, ra, 0

--- a/arch/loongarch/kernel/lbt.S
+++ b/arch/loongarch/kernel/lbt.S
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Author: Lu Zeng <zenglu@loongson.cn>
+ *         Pei Huang <huangpei@loongson.cn>
+ *         Huacai Chen <chenhuacai@loongson.cn>
+ *
+ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
+ */
+#include <asm/asm.h>
+#include <asm/asmmacro.h>
+#include <asm/asm-offsets.h>
+#include <asm/errno.h>
+#include <asm/export.h>
+#include <asm/fpregdef.h>
+#include <asm/loongarch.h>
+#include <asm/regdef.h>
+
+#if defined(CONFIG_CPU_HAS_LBT)
+
+#define SCR_REG_WIDTH 8
+
+	.macro	EX insn, reg, src, offs
+.ex\@:	\insn	\reg, \src, \offs
+	.section __ex_table,"a"
+	PTR	.ex\@, lbt_fault
+	.previous
+	.endm
+
+	.macro sc_save_scr base, tmp0
+	scr2gr	\tmp0, $scr0
+	EX st.d \tmp0, \base, (0 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr1
+	EX st.d \tmp0, \base, (1 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr2
+	EX st.d \tmp0, \base, (2 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr3
+	EX st.d \tmp0, \base, (3 * SCR_REG_WIDTH)
+	.endm
+
+	.macro sc_restore_scr base, tmp0
+	EX ld.d \tmp0, \base, (0 * SCR_REG_WIDTH)
+	gr2scr	\tmp0, $scr0
+	EX ld.d \tmp0, \base, (1 * SCR_REG_WIDTH)
+	gr2scr	\tmp0, $scr1
+	EX ld.d \tmp0, \base, (2 * SCR_REG_WIDTH)
+	gr2scr	\tmp0, $scr2
+	EX ld.d \tmp0, \base, (3 * SCR_REG_WIDTH)
+	gr2scr	\tmp0, $scr3
+	.endm
+
+	.macro sc_save_eflag base, tmp0
+	x86mfflag \tmp0, 0x3f
+	EX st.w \tmp0, \base, 0
+	.endm
+
+	.macro sc_restore_eflag base, tmp0
+	EX ld.w \tmp0, \base, 0
+	x86mtflag \tmp0, 0x3f
+	.endm
+
+/*
+ * Save a thread's lbt context.
+ */
+SYM_FUNC_START(_save_lbt)
+	lbt_save_scr	a0 t1		# clobbers t1
+	lbt_save_eflag	a0 t1		# clobbers t1
+	jirl zero, ra, 0
+SYM_FUNC_END(_save_lbt)
+EXPORT_SYMBOL(_save_lbt)
+
+/*
+ * Restore a thread's lbt context.
+ */
+SYM_FUNC_START(_restore_lbt)
+	lbt_restore_eflag	a0 t1	# clobbers t1
+	lbt_restore_scr		a0 t1	# clobbers t1
+	jirl zero, ra, 0
+SYM_FUNC_END(_restore_lbt)
+EXPORT_SYMBOL(_restore_lbt)
+
+/*
+ * a0: scr
+ * a1: eflag
+ */
+SYM_FUNC_START(_save_lbt_context)
+	sc_save_scr a0 t1
+	sc_save_eflag a1 t1
+	li.w	a0, 0					# success
+	jirl zero, ra, 0
+SYM_FUNC_END(_save_lbt_context)
+
+/*
+ * a0: scr
+ * a1: eflag
+ */
+SYM_FUNC_START(_restore_lbt_context)
+	sc_restore_scr a0 t1
+	sc_restore_eflag a1 t1
+	li.w	a0, 0					# success
+	jirl zero, ra, 0
+SYM_FUNC_END(_restore_lbt_context)
+
+SYM_FUNC_START(lbt_fault)
+	li.w	a0, -EFAULT				# failure
+	jirl zero, ra, 0
+SYM_FUNC_END(lbt_fault)
+
+#else
+
+/*
+ * Save a thread's lbt context.
+ */
+SYM_FUNC_START(_save_lbt)
+	jirl zero, ra, 0
+SYM_FUNC_END(_save_lbt)
+EXPORT_SYMBOL(_save_lbt)
+
+/*
+ * Restore a thread's lbt context.
+ */
+SYM_FUNC_START(_restore_lbt)
+	jirl zero, ra, 0
+SYM_FUNC_END(_restore_lbt)
+EXPORT_SYMBOL(_restore_lbt)
+
+#endif

--- a/arch/loongarch/kernel/process.c
+++ b/arch/loongarch/kernel/process.c
@@ -37,6 +37,7 @@
 #include <asm/cpu.h>
 #include <asm/elf.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/io.h>
 #include <asm/irq.h>
 #include <asm/irq_regs.h>
@@ -81,9 +82,11 @@ void start_thread(struct pt_regs *regs, unsigned long pc, unsigned long sp)
 	euen = regs->csr_euen & ~(CSR_EUEN_FPEN);
 	regs->csr_euen = euen;
 	lose_fpu(0);
+	lose_lbt(0);
 
 	clear_thread_flag(TIF_LSX_CTX_LIVE);
 	clear_thread_flag(TIF_LASX_CTX_LIVE);
+	clear_thread_flag(TIF_LBT_CTX_LIVE);
 	clear_used_math();
 	regs->csr_era = pc;
 	regs->regs[3] = sp;
@@ -169,8 +172,10 @@ int copy_thread(struct task_struct *p, const struct kernel_clone_args *args)
 
 	clear_tsk_thread_flag(p, TIF_USEDFPU);
 	clear_tsk_thread_flag(p, TIF_USEDSIMD);
+	clear_tsk_thread_flag(p, TIF_USEDLBT);
 	clear_tsk_thread_flag(p, TIF_LSX_CTX_LIVE);
 	clear_tsk_thread_flag(p, TIF_LASX_CTX_LIVE);
+	clear_tsk_thread_flag(p, TIF_LBT_CTX_LIVE);
 
 	if (clone_flags & CLONE_SETTLS)
 		childregs->regs[2] = tls;


### PR DESCRIPTION
For supporting lbt in kernel, we need to do:
- lbt context switch save/restore.
- Lazy mode support.
- sigcontext support.
- ptrace context support.