### PR TITLE
Add LBT extensions support

### DIFF
--- a/arch/loongarch/Kconfig
+++ b/arch/loongarch/Kconfig
@@ -484,6 +484,15 @@ config CPU_HAS_LASX
 
 	  If unsure, say Y.
 
+config CPU_HAS_LBT
+	bool "Support for Loongson Binary Translation"
+	help
+	  Loongson Binary Translation (LBT) introduces 4 sketch registers (SCR0 to SCR3),
+	  x86/ARM eflags (eflags) and x87 fpu stack pointer (ftop).
+	  When this option is enabled, the kernel will support allocation and switching
+	  LBT related registers.
+	  If you want to use this feature or Loongson Architecture Translator (LAT), say Y.
+
 config CPU_HAS_PREFETCH
 	bool
 	default y

--- a/arch/loongarch/include/asm/asm-prototypes.h
+++ b/arch/loongarch/include/asm/asm-prototypes.h
@@ -2,6 +2,7 @@
 #include <linux/uaccess.h>
 #include <asm/checksum.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/mmu_context.h>
 #include <asm/page.h>
 #include <asm/ftrace.h>

--- a/arch/loongarch/include/asm/lbt.h
+++ b/arch/loongarch/include/asm/lbt.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Author: Qi Hu <huqi@loongson.cn>
+ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
+ */
+#ifndef _ASM_LBT_H
+#define _ASM_LBT_H
+
+#include <linux/sched.h>
+#include <linux/sched/task_stack.h>
+#include <linux/ptrace.h>
+#include <linux/thread_info.h>
+#include <linux/bitops.h>
+
+#include <asm/cpu.h>
+#include <asm/cpu-features.h>
+#include <asm/current.h>
+#include <asm/loongarch.h>
+#include <asm/processor.h>
+#include <asm/ptrace.h>
+
+#ifdef CONFIG_CPU_HAS_LBT
+
+extern void _save_lbt(struct task_struct *);
+extern void _restore_lbt(struct task_struct *);
+
+static inline int is_lbt_enabled(void)
+{
+	if (!cpu_has_lbt)
+		return 0;
+	return (csr_read32(LOONGARCH_CSR_EUEN) & CSR_EUEN_LBTEN) ?
+		1 : 0;
+}
+
+#define enable_lbt()		set_csr_euen(CSR_EUEN_LBTEN)
+#define disable_lbt()		clear_csr_euen(CSR_EUEN_LBTEN)
+
+static inline int is_lbt_owner(void)
+{
+	return test_thread_flag(TIF_USEDLBT);
+}
+
+static inline void __own_lbt(void)
+{
+	enable_lbt();
+	set_thread_flag(TIF_USEDLBT);
+	KSTK_EUEN(current) |= CSR_EUEN_LBTEN;
+}
+
+static inline void own_lbt_inatomic(int restore)
+{
+	if (cpu_has_lbt && !is_lbt_owner()) {
+		__own_lbt();
+		if (restore)
+			_restore_lbt(current);
+	}
+}
+
+static inline void own_lbt(int restore)
+{
+	preempt_disable();
+	own_lbt_inatomic(restore);
+	preempt_enable();
+}
+
+static inline void __lose_lbt(struct task_struct *tsk)
+{
+	disable_lbt();
+	clear_tsk_thread_flag(tsk, TIF_USEDLBT);
+	KSTK_EUEN(tsk) &= ~(CSR_EUEN_LBTEN);
+}
+
+static inline void lose_lbt_inatomic(int save, struct task_struct *tsk)
+{
+	if (cpu_has_lbt && is_lbt_owner()) {
+		if (save)
+			_save_lbt(tsk);
+		__lose_lbt(tsk);
+	}
+}
+
+static inline void lose_lbt(int save)
+{
+	preempt_disable();
+	lose_lbt_inatomic(save, current);
+	preempt_enable();
+}
+
+static inline void init_lbt(void)
+{
+	set_thread_flag(TIF_LBT_CTX_LIVE);
+	__own_lbt();
+}
+
+/* these functions are not used yet */
+static inline void save_lbt(struct task_struct *tsk)
+{
+	if (cpu_has_lbt)
+		_save_lbt(tsk);
+}
+
+static inline void restore_lbt(struct task_struct *tsk)
+{
+	if (cpu_has_lbt)
+		_restore_lbt(tsk);
+}
+#else
+static inline void own_lbt_inatomic(int restore)
+{}
+static inline void lose_lbt_inatomic(int save, struct task_struct *tsk)
+{}
+static inline void own_lbt(int restore)
+{}
+static inline void lose_lbt(int save)
+{}
+#endif
+
+static inline int thread_lbt_context_live(void)
+{
+	if (!cpu_has_lbt)
+		return 0;
+	return test_thread_flag(TIF_LBT_CTX_LIVE);
+}
+
+#endif /* _ASM_LBT_H */

--- a/arch/loongarch/include/asm/loongarch.h
+++ b/arch/loongarch/include/asm/loongarch.h
@@ -1496,6 +1496,10 @@ __BUILD_CSR_OP(tlbidx)
 #define FPU_CSR_RU	0x200	/* towards +Infinity */
 #define FPU_CSR_RD	0x300	/* towards -Infinity */
 
+/* Bit 6 of FPU Status Register specify the LBT TOP simulation mode */
+#define FPU_CSR_TM_SHIFT	0x6
+#define FPU_CSR_TM		(_ULCAST_(1) << FPU_CSR_TM_SHIFT)
+
 #define read_fcsr(source)	\
 ({	\
 	unsigned int __res;	\

--- a/arch/loongarch/include/asm/processor.h
+++ b/arch/loongarch/include/asm/processor.h
@@ -81,6 +81,7 @@ BUILD_FPR_ACCESS(64)
 struct loongarch_fpu {
 	unsigned int	fcsr;
 	uint64_t	fcc;	/* 8x8 */
+	uint64_t	ftop;
 	union fpureg	fpr[NUM_FPU_REGS];
 };
 

--- a/arch/loongarch/include/asm/switch_to.h
+++ b/arch/loongarch/include/asm/switch_to.h
@@ -8,6 +8,7 @@
 #include <asm/cpu-features.h>
 #include <asm/watch.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 
 struct task_struct;
 
@@ -35,6 +36,7 @@ extern asmlinkage struct task_struct *__switch_to(struct task_struct *prev,
 #define switch_to(prev, next, last)					\
 do {									\
 	lose_fpu_inatomic(1, prev);					\
+	lose_lbt_inatomic(1, prev);					\
 	__process_watch(prev, next);					\
 	(last) = __switch_to(prev, next, task_thread_info(next),	\
 		 __builtin_return_address(0), __builtin_frame_address(0)); \

--- a/arch/loongarch/include/asm/thread_info.h
+++ b/arch/loongarch/include/asm/thread_info.h
@@ -84,7 +84,9 @@ register unsigned long current_stack_pointer __asm__("$r3");
 #define TIF_SINGLESTEP		16	/* Single Step */
 #define TIF_LSX_CTX_LIVE	17	/* LSX context must be preserved */
 #define TIF_LASX_CTX_LIVE	18	/* LASX context must be preserved */
-#define TIF_PATCH_PENDING	19	/* pending live patching update */
+#define TIF_USEDLBT		19	/* LBT was used by this task this quantum (SMP) */
+#define TIF_LBT_CTX_LIVE	20	/* LBT context must be preserved */
+#define TIF_PATCH_PENDING	21	/* pending live patching update */
 
 #define _TIF_SIGPENDING		(1<<TIF_SIGPENDING)
 #define _TIF_NEED_RESCHED	(1<<TIF_NEED_RESCHED)
@@ -102,6 +104,8 @@ register unsigned long current_stack_pointer __asm__("$r3");
 #define _TIF_SINGLESTEP		(1<<TIF_SINGLESTEP)
 #define _TIF_LSX_CTX_LIVE	(1<<TIF_LSX_CTX_LIVE)
 #define _TIF_LASX_CTX_LIVE	(1<<TIF_LASX_CTX_LIVE)
+#define _TIF_USEDLBT		(1<<TIF_USEDLBT)
+#define _TIF_LBT_CTX_LIVE	(1<<TIF_LBT_CTX_LIVE)
 #define _TIF_PATCH_PENDING	(1<<TIF_PATCH_PENDING)
 
 #endif /* __KERNEL__ */

--- a/arch/loongarch/include/uapi/asm/ptrace.h
+++ b/arch/loongarch/include/uapi/asm/ptrace.h
@@ -44,6 +44,12 @@ struct user_fp_state {
 	uint64_t    fpr[32];
 	uint64_t    fcc;
 	uint32_t    fcsr;
+	uint8_t     ftop;
+};
+
+struct user_lbt_state {
+	uint64_t	scr[4];
+	uint32_t	eflags;
 };
 
 struct user_lsx_state {

--- a/arch/loongarch/include/uapi/asm/sigcontext.h
+++ b/arch/loongarch/include/uapi/asm/sigcontext.h
@@ -39,6 +39,7 @@ struct fpu_context {
 	__u64	regs[32];
 	__u64	fcc;
 	__u32	fcsr;
+	__u8	ftop;
 };
 
 /* LSX context */
@@ -58,5 +59,14 @@ struct lasx_context {
 	__u64	fcc;
 	__u32	fcsr;
 };
+
+/* LBT context */
+#define LBT_CTX_MAGIC		0x4c425401
+#define LBT_CTX_ALIGN		8
+struct lbt_context {
+	__u64	regs[4];
+	__u32	eflags;
+};
+
 
 #endif /* _UAPI_ASM_SIGCONTEXT_H */

--- a/arch/loongarch/kernel/Makefile
+++ b/arch/loongarch/kernel/Makefile
@@ -33,6 +33,8 @@ endif
 
 KASAN_SANITIZE_vdso.o := n
 
+obj-$(CONFIG_CPU_HAS_LBT)	+= lbt.o
+
 obj-$(CONFIG_MODULES)		+= module.o module-sections.o
 obj-$(CONFIG_STACKTRACE)	+= stacktrace.o
 

--- a/arch/loongarch/kernel/asm-offsets.c
+++ b/arch/loongarch/kernel/asm-offsets.c
@@ -171,6 +171,7 @@ void output_thread_fpu_defines(void)
 
 	OFFSET(THREAD_FCSR, loongarch_fpu, fcsr);
 	OFFSET(THREAD_FCC,  loongarch_fpu, fcc);
+	OFFSET(THREAD_FTOP, loongarch_fpu, ftop);
 	BLANK();
 }
 

--- a/arch/loongarch/kernel/cpu-probe.c
+++ b/arch/loongarch/kernel/cpu-probe.c
@@ -136,6 +136,20 @@ static void cpu_probe_common(struct cpuinfo_loongarch *c)
 		c->options |= LOONGARCH_CPU_LVZ;
 		elf_hwcap |= HWCAP_LOONGARCH_LVZ;
 	}
+#ifdef CONFIG_CPU_HAS_LBT
+	if (config & CPUCFG2_X86BT) {
+		c->options |= LOONGARCH_CPU_LBT_X86;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_X86;
+	}
+	if (config & CPUCFG2_ARMBT) {
+		c->options |= LOONGARCH_CPU_LBT_ARM;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_ARM;
+	}
+	if (config & CPUCFG2_MIPSBT) {
+		c->options |= LOONGARCH_CPU_LBT_MIPS;
+		elf_hwcap |= HWCAP_LOONGARCH_LBT_MIPS;
+	}
+#endif
 
 	config = read_cpucfg(LOONGARCH_CPUCFG6);
 	if (config & CPUCFG6_PMP)

--- a/arch/loongarch/kernel/fpu.S
+++ b/arch/loongarch/kernel/fpu.S
@@ -165,6 +165,14 @@
 	.macro sc_save_fcsr base, tmp0
 	movfcsr2gr	\tmp0, fcsr0
 	EX	st.w \tmp0, \base, 0
+#if defined(CONFIG_CPU_HAS_LBT)
+	/* TM bit is always 0 if LBT not supported */
+	andi	\tmp0, \tmp0, FPU_CSR_TM
+	beqz	\tmp0, 1f
+	bstrins.d \tmp0, $r0, FPU_CSR_TM_SHIFT, FPU_CSR_TM_SHIFT
+	movgr2fcsr      fcsr0, \tmp0
+	1:
+#endif
 	.endm
 
 	.macro sc_restore_fcsr base, tmp0
@@ -312,6 +320,43 @@
 	EX_XV	0xb2 $xr31, \base, (31 * LASX_REG_WIDTH)
 	.endm
 
+#if defined(CONFIG_CPU_HAS_LBT)
+	.macro sc_save_ftop base, tmp0
+	x86mftop \tmp0
+	EX	st.b \tmp0, \base, 0
+	.endm
+
+	.macro sc_restore_ftop base, tmp0, tmp1
+	EX	ld.b \tmp0, \base, 0
+	la.pcrel \tmp1, 2f
+	alsl.d \tmp1, \tmp0, \tmp1, 3
+	jr \tmp1
+	2:
+	x86mttop 0
+	b 1f
+	x86mttop 1
+	b 1f
+	x86mttop 2
+	b 1f
+	x86mttop 3
+	b 1f
+	x86mttop 4
+	b 1f
+	x86mttop 5
+	b 1f
+	x86mttop 6
+	b 1f
+	x86mttop 7
+	1:
+	.endm
+#else
+	.macro sc_save_ftop base, tmp0
+	.endm
+
+	.macro sc_restore_ftop base, tmp0, tmp1
+	.endm
+#endif
+
 /*
  * Save a thread's fp context.
  */
@@ -328,7 +373,7 @@ EXPORT_SYMBOL(_save_fp)
  */
 SYM_FUNC_START(_restore_fp)
 	fpu_restore_double a0 t1		# clobbers t1
-	fpu_restore_csr	a0 t1
+	fpu_restore_csr	a0 t1 t2
 	fpu_restore_cc	a0 t1 t2		# clobbers t1, t2
 	jirl zero, ra, 0
 SYM_FUNC_END(_restore_fp)
@@ -459,9 +504,11 @@ SYM_FUNC_END(_init_fpu)
  * a0: fpregs
  * a1: fcc
  * a2: fcsr
+ * a3: ftop
  */
 SYM_FUNC_START(_save_fp_context)
 	sc_save_fcc a1 t1 t2
+	sc_save_ftop a3 t1
 	sc_save_fcsr a2 t1
 	sc_save_fp a0
 	li.w	a0, 0					# success
@@ -472,10 +519,12 @@ SYM_FUNC_END(_save_fp_context)
  * a0: fpregs
  * a1: fcc
  * a2: fcsr
+ * a3: ftop
  */
 SYM_FUNC_START(_restore_fp_context)
 	sc_restore_fp a0
 	sc_restore_fcc a1 t1 t2
+	sc_restore_ftop a3 t1 t2
 	sc_restore_fcsr a2 t1
 	li.w	a0, 0					# success
 	jirl zero, ra, 0

--- a/arch/loongarch/kernel/lbt.S
+++ b/arch/loongarch/kernel/lbt.S
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Author: Lu Zeng <zenglu@loongson.cn>
+ *         Pei Huang <huangpei@loongson.cn>
+ *         Huacai Chen <chenhuacai@loongson.cn>
+ *
+ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
+ */
+#include <asm/asm.h>
+#include <asm/asmmacro.h>
+#include <asm/asm-offsets.h>
+#include <asm/errno.h>
+#include <asm/export.h>
+#include <asm/fpregdef.h>
+#include <asm/loongarch.h>
+#include <asm/regdef.h>
+
+#if defined(CONFIG_CPU_HAS_LBT)
+
+#define SCR_REG_WIDTH 8
+
+	.macro	EX insn, reg, src, offs
+.ex\@:	\insn	\reg, \src, \offs
+	.section __ex_table,"a"
+	PTR	.ex\@, lbt_fault
+	.previous
+	.endm
+
+	.macro sc_save_scr base, tmp0
+	scr2gr	\tmp0, $scr0
+	EX st.d \tmp0, \base, (0 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr1
+	EX st.d \tmp0, \base, (1 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr2
+	EX st.d \tmp0, \base, (2 * SCR_REG_WIDTH)
+	scr2gr	\tmp0, $scr3
+	EX st.d \tmp0, \base, (3 * SCR_REG_WIDTH)
+	.endm
+
+	.macro sc_restore_scr base, tmp0
+	EX ld.d \tmp0, \base, (0 * SCR_REG_WIDTH)
+	gr2scr	$scr0, \tmp0
+	EX ld.d \tmp0, \base, (1 * SCR_REG_WIDTH)
+	gr2scr	$scr1, \tmp0
+	EX ld.d \tmp0, \base, (2 * SCR_REG_WIDTH)
+	gr2scr	$scr2, \tmp0
+	EX ld.d \tmp0, \base, (3 * SCR_REG_WIDTH)
+	gr2scr	$scr3, \tmp0
+	.endm
+
+	.macro sc_save_eflag base, tmp0
+	x86mfflag \tmp0, 0x3f
+	EX st.w \tmp0, \base, 0
+	.endm
+
+	.macro sc_restore_eflag base, tmp0
+	EX ld.w \tmp0, \base, 0
+	x86mtflag \tmp0, 0x3f
+	.endm
+
+/*
+ * Save a thread's lbt context.
+ */
+SYM_FUNC_START(_save_lbt)
+	lbt_save_scr	a0 t1		# clobbers t1
+	lbt_save_eflag	a0 t1		# clobbers t1
+	jr ra
+SYM_FUNC_END(_save_lbt)
+EXPORT_SYMBOL(_save_lbt)
+
+/*
+ * Restore a thread's lbt context.
+ */
+SYM_FUNC_START(_restore_lbt)
+	lbt_restore_eflag	a0 t1	# clobbers t1
+	lbt_restore_scr		a0 t1	# clobbers t1
+	jr ra
+SYM_FUNC_END(_restore_lbt)
+EXPORT_SYMBOL(_restore_lbt)
+
+/*
+ * a0: scr
+ * a1: eflag
+ */
+SYM_FUNC_START(_save_lbt_context)
+	sc_save_scr a0 t1
+	sc_save_eflag a1 t1
+	li.w	a0, 0					# success
+	jr ra
+SYM_FUNC_END(_save_lbt_context)
+
+/*
+ * a0: scr
+ * a1: eflag
+ */
+SYM_FUNC_START(_restore_lbt_context)
+	sc_restore_scr a0 t1
+	sc_restore_eflag a1 t1
+	li.w	a0, 0					# success
+	jr ra
+SYM_FUNC_END(_restore_lbt_context)
+
+SYM_FUNC_START(lbt_fault)
+	li.w	a0, -EFAULT				# failure
+	jr ra
+SYM_FUNC_END(lbt_fault)
+
+#else
+
+/*
+ * Save a thread's lbt context.
+ */
+SYM_FUNC_START(_save_lbt)
+	jr ra
+SYM_FUNC_END(_save_lbt)
+EXPORT_SYMBOL(_save_lbt)
+
+/*
+ * Restore a thread's lbt context.
+ */
+SYM_FUNC_START(_restore_lbt)
+	jr ra
+SYM_FUNC_END(_restore_lbt)
+EXPORT_SYMBOL(_restore_lbt)
+
+#endif

--- a/arch/loongarch/kernel/process.c
+++ b/arch/loongarch/kernel/process.c
@@ -37,6 +37,7 @@
 #include <asm/cpu.h>
 #include <asm/elf.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/io.h>
 #include <asm/irq.h>
 #include <asm/irq_regs.h>
@@ -83,9 +84,11 @@ void start_thread(struct pt_regs *regs, unsigned long pc, unsigned long sp)
 	euen = regs->csr_euen & ~(CSR_EUEN_FPEN);
 	regs->csr_euen = euen;
 	lose_fpu(0);
+	lose_lbt(0);
 
 	clear_thread_flag(TIF_LSX_CTX_LIVE);
 	clear_thread_flag(TIF_LASX_CTX_LIVE);
+	clear_thread_flag(TIF_LBT_CTX_LIVE);
 	clear_used_math();
 	regs->csr_era = pc;
 	regs->regs[3] = sp;
@@ -180,8 +183,10 @@ int copy_thread(struct task_struct *p, const struct kernel_clone_args *args)
 
 	clear_tsk_thread_flag(p, TIF_USEDFPU);
 	clear_tsk_thread_flag(p, TIF_USEDSIMD);
+	clear_tsk_thread_flag(p, TIF_USEDLBT);
 	clear_tsk_thread_flag(p, TIF_LSX_CTX_LIVE);
 	clear_tsk_thread_flag(p, TIF_LASX_CTX_LIVE);
+	clear_tsk_thread_flag(p, TIF_LBT_CTX_LIVE);
 
 	if (clone_flags & CLONE_SETTLS)
 		childregs->regs[2] = tls;

--- a/arch/loongarch/kernel/ptrace.c
+++ b/arch/loongarch/kernel/ptrace.c
@@ -35,6 +35,7 @@
 #include <asm/cpu.h>
 #include <asm/cpu-info.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/loongarch.h>
 #include <asm/page.h>
 #include <asm/pgtable.h>
@@ -152,6 +153,9 @@ static int fpr_get(struct task_struct *target,
 
 	r = membuf_write(&to, &target->thread.fpu.fcc, sizeof(target->thread.fpu.fcc));
 	r = membuf_write(&to, &target->thread.fpu.fcsr, sizeof(target->thread.fpu.fcsr));
+#ifdef CONFIG_CPU_HAS_LBT
+	r = membuf_write(&to, &target->thread.fpu.ftop, sizeof(target->thread.fpu.ftop));
+#endif
 
 	return r;
 }
@@ -217,6 +221,13 @@ static int fpr_set(struct task_struct *target,
 	err |= user_regset_copyin(&pos, &count, &kbuf, &ubuf,
 				  &target->thread.fpu.fcsr, fcsr_start,
 				  fcsr_start + sizeof(u32));
+#ifdef CONFIG_CPU_HAS_LBT
+	const int ftop_start = fcsr_start + sizeof(u32);
+
+	err |= user_regset_copyin(&pos, &count, &kbuf, &ubuf,
+				  &target->thread.fpu.ftop, ftop_start,
+				  ftop_start + sizeof(u8));
+#endif
 
 	return err;
 }
@@ -332,6 +343,43 @@ static int simd_set(struct task_struct *target,
 
 #endif /* CONFIG_CPU_HAS_LSX */
 
+#ifdef CONFIG_CPU_HAS_LBT
+static int lbt_get(struct task_struct *target,
+		   const struct user_regset *regset,
+		   struct membuf to)
+{
+	int r;
+
+	r = membuf_write(&to, &target->thread.scr0, sizeof(target->thread.scr0));
+	r = membuf_write(&to, &target->thread.scr1, sizeof(target->thread.scr1));
+	r = membuf_write(&to, &target->thread.scr2, sizeof(target->thread.scr2));
+	r = membuf_write(&to, &target->thread.scr3, sizeof(target->thread.scr3));
+
+	r = membuf_write(&to, &target->thread.eflags, sizeof(target->thread.eflags));
+
+	return r;
+}
+
+static int lbt_set(struct task_struct *target,
+		   const struct user_regset *regset,
+		   unsigned int pos, unsigned int count,
+		   const void *kbuf, const void __user *ubuf)
+{
+	const int eflags_start = 4 * sizeof(target->thread.scr0);
+	const int eflags_end = eflags_start + sizeof(u32);
+	int err = 0;
+
+	err |= user_regset_copyin(&pos, &count, &kbuf, &ubuf,
+				  &target->thread.scr0,
+				  0, 4 * sizeof(target->thread.scr0));
+	err |= user_regset_copyin(&pos, &count, &kbuf, &ubuf,
+				  &target->thread.eflags,
+				  eflags_start, eflags_end);
+
+	return err;
+}
+#endif
+
 struct pt_regs_offset {
 	const char *name;
 	int offset;
@@ -411,6 +459,9 @@ enum loongarch_regset {
 #ifdef CONFIG_CPU_HAS_LASX
 	REGSET_LASX,
 #endif
+#ifdef CONFIG_CPU_HAS_LBT
+	REGSET_LBT,
+#endif
 };
 
 static const struct user_regset loongarch64_regsets[] = {
@@ -456,6 +507,16 @@ static const struct user_regset loongarch64_regsets[] = {
 		.align		= 32,
 		.regset_get	= simd_get,
 		.set		= simd_set,
+	},
+#endif
+#ifdef CONFIG_CPU_HAS_LBT
+	[REGSET_LBT] = {
+		.core_note_type	= NT_LOONGARCH_LBT,
+		.n		= 5,
+		.size		= sizeof(u64),
+		.align		= sizeof(u64),
+		.regset_get = lbt_get,
+		.set		= lbt_set,
 	},
 #endif
 };

--- a/arch/loongarch/kernel/traps.c
+++ b/arch/loongarch/kernel/traps.c
@@ -35,6 +35,7 @@
 #include <asm/break.h>
 #include <asm/cpu.h>
 #include <asm/fpu.h>
+#include <asm/lbt.h>
 #include <asm/loongarch.h>
 #include <asm/mmu_context.h>
 #include <asm/pgtable.h>
@@ -628,6 +629,25 @@ static void init_restore_lasx(void)
 	BUG_ON(!is_lasx_enabled());
 }
 
+#ifdef CONFIG_CPU_HAS_LBT
+static void init_restore_lbt(void)
+{
+	if (!thread_lbt_context_live()) {
+		/* First time lbt context user */
+		init_lbt();
+	} else {
+		/* Enable and restore */
+		if (!is_lbt_owner())
+			own_lbt_inatomic(1);
+	}
+
+	BUG_ON(!is_lbt_enabled());
+}
+#else
+static void init_restore_lbt(void)
+{}
+#endif
+
 asmlinkage void noinstr do_fpu(struct pt_regs *regs)
 {
 	irqentry_state_t state = irqentry_enter(regs);
@@ -693,7 +713,19 @@ asmlinkage void noinstr do_lbt(struct pt_regs *regs)
 	irqentry_state_t state = irqentry_enter(regs);
 
 	local_irq_enable();
-	force_sig(SIGILL);
+
+	if (cpu_has_lbt) {
+		preempt_disable();
+		init_restore_lbt();
+		preempt_enable();
+	} else {
+		/*
+		 * If cpu do not support lbt or do not define CPU_HAS_LBT.
+		 * The kernel need to raise SIGILL.
+		 */
+		force_sig(SIGILL);
+	}
+
 	local_irq_disable();
 
 	irqentry_exit(regs, state);


### PR DESCRIPTION
Loongson Binary Translation (LBT) is used to accelerate binary translation, which contains 4 sketch registers (`scr0` to `scr3`), x86/ARM eflags (`eflags`) and x87 fpu stack pointer (`ftop`).

This patch support kernel to save/restore these registers, handle the LBT exception and maintain sigcontext.

For supporting lbt in kernel, we need to do:

- lbt context switch save/restore (Lazy mode).
- sigcontext support.
- ptrace context support.